### PR TITLE
Make IDs length adaptive

### DIFF
--- a/src/service/url.rs
+++ b/src/service/url.rs
@@ -5,7 +5,22 @@ use actix_web::{get, post, web, Responder, Scope};
 use serde::{Deserialize, Serialize};
 
 pub fn mount(scope: Scope) -> Scope {
-    scope.service(url_get).service(url_post)
+    let id_state = IdState::new(2);
+    // create thread-local id_state so we don't need to care about sync/sharing
+    scope.data(id_state).service(url_get).service(url_post)
+}
+
+#[derive(Debug)]
+struct IdState {
+    id_length: std::cell::Cell<usize>,
+}
+
+impl IdState {
+    fn new(start_length: usize) -> Self {
+        IdState {
+            id_length: std::cell::Cell::new(start_length),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -35,8 +50,75 @@ impl<'a> UrlCreateRs<'a> {
     }
 }
 
-fn get_id() -> String {
-    nanoid::nanoid!(2)
+// TODO: This should be an actor, because we should count retries for all threads globally,
+// not just the current one, otherwise when the server is under load we might have many more
+// retries than we want until we increment the length.
+#[derive(Debug)]
+struct IdGenerator {
+    current_attempts: usize,
+    pub current_length: usize,
+    pub max_retries: usize,
+    pub increment_after: usize,
+}
+
+impl IdGenerator {
+    fn new(current_length: usize) -> Self {
+        IdGenerator {
+            current_length,
+            current_attempts: 0,
+            max_retries: 10,
+            increment_after: 3,
+        }
+    }
+
+    fn next(&mut self) -> Option<String> {
+        print!(
+            "IdGenerator::next(), current_attempts={:?}",
+            self.current_attempts,
+        );
+        self.current_attempts += 1;
+        if self.current_attempts > self.max_retries {
+            print!("IdGenerator::next() max attempts reached");
+            return None;
+        }
+        if (self.current_attempts % self.increment_after) == 0 {
+            self.current_length += 1;
+            print!("IdGenerator::next() new length={:?}", self.current_length);
+        }
+        let len = self.current_length;
+        let id = nanoid::nanoid!(len);
+        dbg!(&id);
+        Some(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn id_generator() {
+        let mut gen = IdGenerator::new(1);
+        assert_eq!(gen.current_length, 1);
+        assert!(gen.increment_after <= gen.max_retries);
+
+        let mut current_length = 1;
+        let mut total_retries = 0;
+        let mut inc_after = 0;
+        while total_retries < gen.max_retries {
+            total_retries += 1;
+            inc_after += 1;
+            let id = gen.next();
+            if total_retries > gen.max_retries {
+                assert!(id.is_none());
+            }
+            assert!(id.is_some());
+            if inc_after == gen.increment_after {
+                inc_after = 0;
+                current_length += 1;
+            }
+            assert_eq!(id.unwrap().len(), current_length);
+        }
+    }
 }
 
 #[get("{id}")]
@@ -52,19 +134,29 @@ async fn url_get(path: web::Path<(String,)>, state: web::Data<SharedState>) -> i
 }
 
 #[post("")]
-async fn url_post(rq: web::Json<UrlCreateRq>, state: web::Data<SharedState>) -> impl Responder {
+async fn url_post(
+    rq: web::Json<UrlCreateRq>,
+    id_state: web::Data<IdState>,
+    state: web::Data<SharedState>,
+) -> impl Responder {
     use crate::url_info::ResourceInfo;
 
     let info = ResourceInfo::fetch(&rq.url).await.unwrap();
     dbg!(&info);
-    let mut id = get_id();
+
+    // We use Relaxed ordering everywhere because we don't actually need very strong guarantees of
+    // this counter, is not a big deal if in some thread the update is a bit delayed or if it gets
+    // incremented twice, is just a small inconvenience, but the value of this length is all a big
+    // heuristic.
+    let mut idgen = IdGenerator::new(id_state.id_length.get());
+    dbg!(&idgen);
 
     let mut write_db = state.db.write().unwrap();
-    // TODO: limit looping
-    loop {
+    use actix_web::HttpResponse;
+    while let Some(id) = idgen.next() {
         use std::collections::hash_map;
         match write_db.entry(id.to_string()) {
-            hash_map::Entry::Occupied(_) => id = get_id(),
+            hash_map::Entry::Occupied(_) => continue, // retry with next ID
             hash_map::Entry::Vacant(e) => {
                 use crate::config::config;
                 let entry = e.insert(Entry {
@@ -72,9 +164,17 @@ async fn url_post(rq: web::Json<UrlCreateRq>, state: web::Data<SharedState>) -> 
                     source_url: info.url.as_ref().unwrap().clone(), // URL should always exist here
                     noclick_url: info.urlize(config().link.max_length).unwrap(),
                 });
-                use actix_web::HttpResponse;
+                id_state.id_length.set(idgen.current_length);
                 return HttpResponse::Ok().json(UrlCreateRs::from_entry(&entry, &config()));
             }
         };
     }
+    id_state.id_length.set(idgen.current_length);
+
+    HttpResponse::ServiceUnavailable()
+        .header("Retry-After", "120")
+        .json(format!(
+            "{{\"error\": \"Unable to get an ID for the new URL after {} attempts\"}}",
+            idgen.max_retries
+        ))
 }


### PR DESCRIPTION
The adaptive ID length is still a bit naive, but it should be enough for
now. The scheme is like this:

* We store a thread-local `id_length` storing the current length (2 at
  program start).

* The for every request we create an ID generator that will handle
  retries, but remember these retries will be thread-local and will be
  reset on each request.

* The ID generator generates an ID with the current `id_length`.

* If there is a collision, a new ID is generated and the collision
  counted.

* Every 3 consecutive collisions, the ID length is incremented and the
  retrying continues until a maximum of 10 attempts.

* If all attempts are exhausted, the new ID length is updated in the
  thread-local storage and a ServiceUnavailable response is sent
  (suggesting to retry in 2 minutes). This is just a safety net in case
  of a bug so a request doesn't end up in an infinite loop accidentally.
  It should be extremely rare that so many retries fail to allocate a
  free ID.

* If a free ID is found, the new ID length is also updated in the
  thread-local storage so it can be used by the next request and a
  success response is sent.

Fixes #17 although using a simpler algorithm. Decreasing the length is
not yet implemented (and it doesn't make sense until we implement an
expiry for created URLs).