### PR TITLE
Build and view fixes and save the complete expanded URL to the DB

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 mod cli;
 mod config;
 mod service;
-mod state;
 mod url_info;
 mod urlize;
 

--- a/src/service/view.rs
+++ b/src/service/view.rs
@@ -14,17 +14,16 @@ async fn view(
     dbg!(&rest);
 
     let mut db_conn = db_pool.acquire().await.unwrap();
-    let row = sqlx::query(r"SELECT noclick_url FROM urls WHERE id = $1")
+    let row = sqlx::query(r"SELECT source_url FROM urls WHERE id = $1")
         .bind(&id)
         .fetch_one(&mut db_conn)
         .await
         .unwrap();
 
-    use crate::config::config;
     use actix_web::{http::header::LOCATION, HttpResponse};
     use sqlx::Row;
-    let noclick_url: &str = row.try_get("noclick_url").unwrap();
-    let mut url = format!("{}/{}/{}", config().link.base_url, id, noclick_url);
-    url.truncate(config().link.max_length);
-    HttpResponse::Found().set_header(LOCATION, url).finish()
+    let source_url: &str = row.try_get("source_url").unwrap();
+    HttpResponse::Found()
+        .set_header(LOCATION, source_url)
+        .finish()
 }


### PR DESCRIPTION
The build was failing because the `state` module was removed in the previous commit but the declaration was left in the main file.

The `Location` header URL was mistakenlyis being set to the `noclick_url`, so viewing URLs wasn't really working. Now being set to the `source_url`.

We were saving only the expanded path component in the DB, not the complete URL with a complete schema including the "view" host and URL ID. This is to make it easier to port a DB to a different "view" host, but it should actually be a very rare case and it should be easy enough to batch-convert the DB if that's ever needed. This would avoid doing any processing to build the noclick_url when retrieving the record, which should be a more common case than changing the "view" host.

All that said, it's worth mentioning that the noclick_url is being saved but not really used. It could be not saved at all, but for now we keep it for debugging purposes. It might be a good thing for privacy to not save it at all.